### PR TITLE
#30 Dto의 Serializable 제거

### DIFF
--- a/src/main/java/io/laaf/fastcampusprojectboard/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/io/laaf/fastcampusprojectboard/dto/response/ArticleCommentResponse.java
@@ -2,7 +2,6 @@ package io.laaf.fastcampusprojectboard.dto.response;
 
 import io.laaf.fastcampusprojectboard.dto.ArticleCommentDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 public record ArticleCommentResponse(


### PR DESCRIPTION
JPA Buddy 를 이용해 작성한 DTO들인데,
자동으로 `implements Serializable` 이 들어가버림
우리 프로젝트는 직렬화로 Jackson을 사용하므로
필요하지 않고, 의도하여 넣은 코드도 아님
그러므로 삭제

This closes #30 