### PR TITLE
헤로쿠 배포하기 DB 변경: ClearDB -> JAWSDB

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,7 +51,8 @@ spring:
     activate:
       on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
조사해본 결과 cleardb의 기본 mysql버전이(5.6)너무 낮아서 jawsDB(8.0)로 변경.
5.6에서는 `article_comment_content` 인덱스 사이즈가 너무 큼.

This fixes #50 

* https://devcenter.heroku.com/articles/cleardb

